### PR TITLE
Requirement filter doesn't require the presence of CustomJSONData lib in Quest.

### DIFF
--- a/src/DataAccess/SongBrowserModel.cpp
+++ b/src/DataAccess/SongBrowserModel.cpp
@@ -548,7 +548,7 @@ namespace SongBrowser
         INFO("Starting filtering songs by %s", SongFilterModeToString(config.filterMode).c_str());
         auto stopwatch = System::Diagnostics::Stopwatch::New_ctor();
         stopwatch->Start();
-
+/*     >>>>>>> NOT REQUIRED IN QUEST
         if (config.filterMode == SongFilterMode::Requirements)
         {
             auto modList = Modloader::getMods();
@@ -559,7 +559,7 @@ namespace SongBrowser
                 config.filterMode = SongFilterMode::None;
             }
         }
-
+*/
         switch (config.filterMode)
         {
             case SongFilterMode::Favorites:

--- a/src/UI/Browser/SongBrowserUI.cpp
+++ b/src/UI/Browser/SongBrowserUI.cpp
@@ -413,7 +413,7 @@ namespace SongBrowser::UI
                 }, p.first);
             UIUtils::SetButtonTextSize(filterButton->button, filterButtonFontSize);
             UIUtils::ToggleWordWrapping(filterButton->button, false);
-
+/*     >>>>>>> NOT REQUIRED IN QUEST
             // don't allow to filter for reqs if no cjd
             if (p.second == SongFilterMode::Requirements)
             {
@@ -427,7 +427,7 @@ namespace SongBrowser::UI
                 else filterButton->button->set_interactable(false);
 
             }
-
+*/
             filterButtonGroup->Add(filterButton);
             i++;
         }


### PR DESCRIPTION
The current port disables the filter by requirement feature when CustomJSONData is not loaded. But this lib is not really required for this function to work, so this PR removes this check and works regardless the presence of CJD lib.